### PR TITLE
chore: sync main into develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -1,0 +1,10 @@
+name: Auto Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  conflicts:
+    uses: preprio/.github-workflows/.github/workflows/code-conflicts.yml@main
+    secrets: inherit


### PR DESCRIPTION
This PR syncs `main` into `develop` because `main` is ahead.

- Detected ahead commits: 7
